### PR TITLE
Check if pjobs defined to prevent crashes

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,9 @@
 export EXTERNALS_CLASP_HOME ?= $(shell pwd)
 
 include $(wildcard $(EXTERNALS_CLASP_HOME)/local.config)
+ifndef PJOBS
+	PJOBS=1
+endif
 
 export BUILTIN_INCLUDES ?= /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
 


### PR DESCRIPTION
Having just crashed my machine, by not reading the build instructions carefully, I thought this might be helpful.